### PR TITLE
chore(actions): Adds workflow for PyPI publishing

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,0 +1,15 @@
+name: Check release notes
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v3
+        with:
+          changelog: CHANGES.md

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,24 @@
+name: PyPI
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+            enable-cache: true
+            version: "0.7.x"
+
+      - name: Build
+        run: uv build
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.pypi_token }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,24 @@
 # Change Log
 
+The following changes are not yet released, but are code complete:
+
+Features:
+-
+
+Changes:
+-
+
+Fixes:
+-
+
 ## Current
 
-0.0.1 - Initial release
+**0.0.1 - 2025-07-08**
+
+- First public release of the package.
+- Provides core functionality
+- Adds automated publishing to PyPI via GitHub Actions.
+- Adds workflow to enforce changelog updates on pull requests.
 
 ## Past
 


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow to automatically build and publish packages to PyPI whenever a version tag (`v*.*.*`) is pushed.

In addition to publishing automation, this PR adds a workflow to check that all pull requests targeting main include an update to the `CHANGES.md` file.

Fixes #2 

--------

### Additional Note:

This PR has not been tagged with a release version yet. Once it is approved, the plan is to push a version tag to trigger the publishing workflow and complete the release process.